### PR TITLE
Fix hero image broken aspect ratio on mobile viewports

### DIFF
--- a/aartics/projects/assets_v4/css/aartics_projects_v4.css
+++ b/aartics/projects/assets_v4/css/aartics_projects_v4.css
@@ -531,3 +531,30 @@ header {
 .no-padding {
   padding: 0;
 }
+
+/* --- Mobile responsive fixes for hero image --- */
+@media screen and (max-width: 767px) {
+  #heroimage {
+    height: auto;
+  }
+
+  #heroimageimg {
+    height: auto;
+    width: 100%;
+    padding: 30px 15px 15px 15px;
+    object-fit: contain;
+  }
+
+  #intro-text {
+    height: auto;
+    padding-bottom: 40px;
+  }
+
+  #intro-logo {
+    margin-top: 40px;
+  }
+
+  #downarrow {
+    margin-top: 30px;
+  }
+}

--- a/docs/projects/assets_v4/css/aartics_projects_v4.css
+++ b/docs/projects/assets_v4/css/aartics_projects_v4.css
@@ -531,3 +531,30 @@ header {
 .no-padding {
   padding: 0;
 }
+
+/* --- Mobile responsive fixes for hero image --- */
+@media screen and (max-width: 767px) {
+  #heroimage {
+    height: auto;
+  }
+
+  #heroimageimg {
+    height: auto;
+    width: 100%;
+    padding: 30px 15px 15px 15px;
+    object-fit: contain;
+  }
+
+  #intro-text {
+    height: auto;
+    padding-bottom: 40px;
+  }
+
+  #intro-logo {
+    margin-top: 40px;
+  }
+
+  #downarrow {
+    margin-top: 30px;
+  }
+}


### PR DESCRIPTION
## Summary
Fix the hero image on project pages that has a broken aspect ratio on mobile devices, making the image invisible/distorted.

## Problem
The hero image (`#heroimageimg`) had a fixed `height: 750px` and `padding: 50px 0 0 50px` in `aartics_projects_v4.css`. On mobile screens (< 768px), the image container becomes full-width via Bootstrap grid (`col-sm-8` → 100%), but the fixed height causes the image to be clipped or distorted since there is no responsive scaling.

## Fix
Added a responsive CSS media query for screens ≤ 767px that:
- Removes fixed height on `#heroimage` container (was `760px` → `auto`)
- Removes fixed height on `#heroimageimg` (was `750px` → `auto`)
- Makes image scale to `width: 100%` with `height: auto`
- Uses `object-fit: contain` to preserve aspect ratio
- Reduces padding for mobile screens
- Also adjusts `#intro-text`, `#intro-logo`, and `#downarrow` spacing for mobile

Applied to both `aartics/` and `docs/` CSS files.

## Affected Pages
All 13 project pages (resonateai, sfac, wolflion, karunavr, barcelona, assen, coimbatore, mumbai, bendy, octet, allsportsbar, graphics, aartics_story).